### PR TITLE
Fix problem with SE reads reporting

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.2.1
+    1.2.2
 
 owners:
     [psdehal, dylan, wjriehl]

--- a/lib/kb_trimmomatic/kb_trimmomaticImpl.py
+++ b/lib/kb_trimmomatic/kb_trimmomaticImpl.py
@@ -295,8 +295,6 @@ execTrimmomaticSingleLibrary() runs Trimmomatic on a single library
         report_lib_names = []
         lib_i = -1
 
-        pprint(trimmomatic_retVal)
-
         # This is some powerful brute force nonsense, but it should be okay.
         se_report_re = re.compile('^Input Reads:\s*(\d+)\s*Surviving:\s*(\d+)\s*\(\d+\.\d+\%\)\s*Dropped:\s*(\d+)\s*\(\d+\.\d+\%\)')
         for line in trimmomatic_retVal['report'].split("\n"):
@@ -343,9 +341,6 @@ execTrimmomaticSingleLibrary() runs Trimmomatic on a single library
 #                        'chicken': 14,
 #                        'applesauce': 1
 #                        }
-
-        pprint(report_field_order)
-        pprint(report_data)
 
         for lib_i in range(len(report_data)):
             html_report_lines += ['<p><b><font color="'+text_color+'">TRIMMOMATIC RESULTS FOR '+str(report_lib_names[lib_i])+' (object '+str(report_lib_refs[lib_i])+')</font></b><br>'+"\n"]

--- a/lib/kb_trimmomatic/kb_trimmomaticImpl.py
+++ b/lib/kb_trimmomatic/kb_trimmomaticImpl.py
@@ -294,6 +294,11 @@ execTrimmomaticSingleLibrary() runs Trimmomatic on a single library
         report_lib_refs = []
         report_lib_names = []
         lib_i = -1
+
+        pprint(trimmomatic_retVal)
+
+        # This is some powerful brute force nonsense, but it should be okay.
+        se_report_re = re.compile('^Input Reads:\s*(\d+)\s*Surviving:\s*(\d+)\s*\(\d+\.\d+\%\)\s*Dropped:\s*(\d+)\s*\(\d+\.\d+\%\)')
         for line in trimmomatic_retVal['report'].split("\n"):
             if line.startswith("RUNNING"):
                 lib_i += 1
@@ -308,6 +313,10 @@ execTrimmomaticSingleLibrary() runs Trimmomatic on a single library
             elif len(line) == 0:
                 continue
             else:
+                m = se_report_re.match(line)
+                if m and len(m.groups()) == 3:
+                    report_field_order[lib_i] = ['Input Reads', 'Surviving', 'Dropped']
+                    report_data[lib_i] = dict(zip(report_field_order[lib_i], m.groups()))
                 try:
                     [f_name, val] = line.split(': ')
                     int_val = int(val)
@@ -334,6 +343,9 @@ execTrimmomaticSingleLibrary() runs Trimmomatic on a single library
 #                        'chicken': 14,
 #                        'applesauce': 1
 #                        }
+
+        pprint(report_field_order)
+        pprint(report_data)
 
         for lib_i in range(len(report_data)):
             html_report_lines += ['<p><b><font color="'+text_color+'">TRIMMOMATIC RESULTS FOR '+str(report_lib_names[lib_i])+' (object '+str(report_lib_refs[lib_i])+')</font></b><br>'+"\n"]

--- a/test/kb_trimmomatic_server_test.py
+++ b/test/kb_trimmomatic_server_test.py
@@ -557,7 +557,6 @@ class kb_trimmomaticTest(unittest.TestCase):
 
     ### TEST 2: run Trimmomatic against just one paired end library
     #
-    @unittest.skip
     def test_runTrimmomatic_PairedEndLibrary(self):
 
         print ("\n\nRUNNING: test_runTrimmomatic_PairedEndLibrary()")
@@ -608,7 +607,6 @@ class kb_trimmomaticTest(unittest.TestCase):
 
     ### TEST 3: run Trimmomatic against a Single End Library reads set
     #
-    @unittest.skip
     def test_runTrimmomatic_SingleEndLibrary_ReadsSet(self):
 
         print ("\n\nRUNNING: test_runTrimmomatic_SingleEndLibrary_ReadsSet()")
@@ -708,7 +706,6 @@ class kb_trimmomaticTest(unittest.TestCase):
 
     ### TEST 5: run Trimmomatic against a Single End Library sample set
     #
-    @unittest.skip
     def test_runTrimmomatic_SingleEndLibrary_SampleSet(self):
 
         print ("\n\nRUNNING: test_runTrimmomatic_SingleEndLibrary_SampleSet()")
@@ -757,7 +754,6 @@ class kb_trimmomaticTest(unittest.TestCase):
         self.assertEqual(trimmed_reads_info[2].split('-')[0],'KBaseSets.ReadsSet')
 
     ### TEST 6: run Trimmomatic with data that doesn't get trimmed, check report output.
-    @unittest.skip
     def test_runTrimmomatic_SingleEndLibrary_no_trimming(self):
         print("\n\nRUNNING: test_runTrimmomatic_SingleEndLibrary_no_trimming")
         print("---------------------------------------------------------\n\n")
@@ -842,4 +838,6 @@ class kb_trimmomaticTest(unittest.TestCase):
         with self.assertRaises(Exception):
             self.wsClient.get_object_info([{'ref': se_lib_info[7] + '/' + output_name}], 1)
         report_obj = self.wsClient.get_objects([{'ref': result[0]['report_ref']}])[0]
-        self.assertIn('All reads were trimmed', report_obj['data']['direct_html'])
+        self.assertIn('Input Reads', report_obj['data']['direct_html'])
+        self.assertIn('Surviving', report_obj['data']['direct_html'])
+        self.assertIn('Dropped', report_obj['data']['direct_html'])

--- a/test/kb_trimmomatic_server_test.py
+++ b/test/kb_trimmomatic_server_test.py
@@ -557,6 +557,7 @@ class kb_trimmomaticTest(unittest.TestCase):
 
     ### TEST 2: run Trimmomatic against just one paired end library
     #
+    @unittest.skip
     def test_runTrimmomatic_PairedEndLibrary(self):
 
         print ("\n\nRUNNING: test_runTrimmomatic_PairedEndLibrary()")
@@ -607,6 +608,7 @@ class kb_trimmomaticTest(unittest.TestCase):
 
     ### TEST 3: run Trimmomatic against a Single End Library reads set
     #
+    @unittest.skip
     def test_runTrimmomatic_SingleEndLibrary_ReadsSet(self):
 
         print ("\n\nRUNNING: test_runTrimmomatic_SingleEndLibrary_ReadsSet()")
@@ -706,6 +708,7 @@ class kb_trimmomaticTest(unittest.TestCase):
 
     ### TEST 5: run Trimmomatic against a Single End Library sample set
     #
+    @unittest.skip
     def test_runTrimmomatic_SingleEndLibrary_SampleSet(self):
 
         print ("\n\nRUNNING: test_runTrimmomatic_SingleEndLibrary_SampleSet()")
@@ -754,6 +757,7 @@ class kb_trimmomaticTest(unittest.TestCase):
         self.assertEqual(trimmed_reads_info[2].split('-')[0],'KBaseSets.ReadsSet')
 
     ### TEST 6: run Trimmomatic with data that doesn't get trimmed, check report output.
+    @unittest.skip
     def test_runTrimmomatic_SingleEndLibrary_no_trimming(self):
         print("\n\nRUNNING: test_runTrimmomatic_SingleEndLibrary_no_trimming")
         print("---------------------------------------------------------\n\n")


### PR DESCRIPTION
If all reads were trimmed, or no reads were trimmed, it always said that all reads were trimmed. Now it paints the HTML report like the PE version did.